### PR TITLE
Fix CI build and update Android build properties

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:
@@ -31,3 +34,8 @@ jobs:
           channel: 'stable'
       - run: flutter pub get
       - run: flutter build apk
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release
+          path: build/app/outputs/flutter-apk/app-release.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           channel: 'stable'
       - run: flutter pub get
+      - name: Create gradle.properties
+        run: |
+          echo "android.useAndroidX=true" >> android/gradle.properties
+          echo "android.enableJetifier=true" >> android/gradle.properties
       - run: flutter build apk
       - name: Upload APK
         uses: actions/upload-artifact@v3

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -56,6 +56,7 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+-dontwarn com.stripe.android.pushProvisioning.**

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,9 +1,12 @@
 pluginManagement {
     def flutterSdkPath = {
         def properties = new Properties()
-        file("local.properties").withInputStream { properties.load(it) }
-        def flutterSdkPath = properties.getProperty("flutter.sdk")
-        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        def propertiesFile = file("local.properties")
+        if (propertiesFile.exists()) {
+            propertiesFile.withInputStream { properties.load(it) }
+        }
+        def flutterSdkPath = properties.getProperty("flutter.sdk") ?: System.getenv("FLUTTER_ROOT")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties, and FLUTTER_ROOT environment variable not set."
         return flutterSdkPath
     }()
 
@@ -18,8 +21,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.2.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.2.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Fix CI build failures by updating AGP/KGP version and adding CI specific fallback for local.properties. Includes ProGuard workaround for flutter_stripe on release builds and adds a CI step to upload the built APK artifact.

---
*PR created automatically by Jules for task [8349376061839055150](https://jules.google.com/task/8349376061839055150) started by @FabioAmorim1501*