### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Input Validation to Authentication Screens

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-24 - Missing Input Validation
+**Vulnerability:** Lack of client-side input validation on authentication screens (login and signup).
+**Learning:** Found that basic UI forms for sensitive operations were not validating input format or strength, which can lead to unnecessary backend calls with invalid data or weak passwords.
+**Prevention:** Implement validation logic at the UI boundary before calling authentication services. Ensure minimum password complexity and valid email formats are checked.

--- a/lib/src/features/auth/login_screen.dart
+++ b/lib/src/features/auth/login_screen.dart
@@ -38,12 +38,26 @@ class _LoginScreenState extends State<LoginScreen> {
             ),
             ElevatedButton(
               onPressed: () async {
+                final email = _emailController.text.trim();
+                final password = _passwordController.text;
+
+                if (email.isEmpty || password.isEmpty) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Please enter email and password.')),
+                  );
+                  return;
+                }
+
                 final user = await _auth.login(
-                  _emailController.text,
-                  _passwordController.text,
+                  email,
+                  password,
                 );
                 if (user != null) {
                   Navigator.pushReplacementNamed(context, '/home');
+                } else {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Login failed. Please check your credentials.')),
+                  );
                 }
               },
               child: const Text('Login'),

--- a/lib/src/features/auth/signup_screen.dart
+++ b/lib/src/features/auth/signup_screen.dart
@@ -38,9 +38,26 @@ class _SignupScreenState extends State<SignupScreen> {
             ),
             ElevatedButton(
               onPressed: () async {
+                final email = _emailController.text.trim();
+                final password = _passwordController.text;
+
+                if (email.isEmpty || !email.contains('@')) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Please enter a valid email address.')),
+                  );
+                  return;
+                }
+
+                if (password.length < 8) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Password must be at least 8 characters long.')),
+                  );
+                  return;
+                }
+
                 final user = await _auth.signUp(
-                  _emailController.text,
-                  _passwordController.text,
+                  email,
+                  password,
                 );
                 if (user != null) {
                   Navigator.pushReplacementNamed(context, '/home');


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Lack of client-side validation for emails and passwords on authentication screens before backend calls.
🎯 Impact: Could allow blank submissions or insecure passwords to hit the auth backend unnecessarily, or create users with weak passwords if the backend didn't enforce it rigidly.
🔧 Fix: Added email and password validation at the UI boundary before auth service calls in `signup_screen.dart` and `login_screen.dart`.
✅ Verification: Ensure the app correctly shows `ScaffoldMessenger` snackbars when invalid inputs are provided and does not attempt login or signup until resolved. All tests pass successfully.

---
*PR created automatically by Jules for task [6435003939152417387](https://jules.google.com/task/6435003939152417387) started by @FabioAmorim1501*