### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix information disclosure in auth logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Information Disclosure in Error Logging]
+**Vulnerability:** Raw `FirebaseAuthException` objects were being logged directly using `print(e)`. This can leak sensitive data (e.g., user emails) or implementation details from the stack trace to anyone with access to the application logs.
+**Learning:** Generic error logging is required to prevent sensitive information disclosure.
+**Prevention:** Always use generic error messages when logging authentication errors or errors that may contain user-provided data or internal system details.

--- a/lib/src/services/auth_service.dart
+++ b/lib/src/services/auth_service.dart
@@ -13,8 +13,8 @@ class AuthService {
       );
       return userCredential.user;
     } on FirebaseAuthException catch (e) {
-      // Handle exceptions
-      print(e);
+      // Handle exceptions securely: avoid leaking raw exception details
+      print('Authentication error during sign up.');
       return null;
     }
   }
@@ -27,8 +27,8 @@ class AuthService {
       );
       return userCredential.user;
     } on FirebaseAuthException catch (e) {
-      // Handle exceptions
-      print(e);
+      // Handle exceptions securely: avoid leaking raw exception details
+      print('Authentication error during login.');
       return null;
     }
   }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Raw `FirebaseAuthException` objects were being logged directly to the console when authentication failed in `auth_service.dart`. This could leak sensitive data (like user emails) or internal implementation details from stack traces into application logs.
🎯 Impact: Anyone with access to the application logs could potentially view sensitive user information or internal system details.
🔧 Fix: Replaced raw exception logging (`print(e)`) with generic, safe error messages that do not expose internal details.
✅ Verification: Ran `flutter test` to ensure changes didn't break functionality. Verify by attempting an invalid login/signup and checking the logs for generic error messages.

---
*PR created automatically by Jules for task [13700705762729718974](https://jules.google.com/task/13700705762729718974) started by @FabioAmorim1501*