### PR TITLE
⚡ Bolt: Prevent memory leaks in forms

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - [Memory Leaks in Flutter Forms]
+**Learning:** Forgetting to explicitly dispose of `TextEditingController` instances in `StatefulWidget`s leads to memory leaks because they hold onto native resources that Flutter doesn't automatically release.
+**Action:** Always implement a `dispose()` method in `StatefulWidget`s to clean up controllers when the widget is removed from the widget tree.

--- a/lib/src/features/auth/login_screen.dart
+++ b/lib/src/features/auth/login_screen.dart
@@ -14,6 +14,15 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _passwordController = TextEditingController();
 
   @override
+  void dispose() {
+    // ⚡ Bolt: Prevent memory leaks by explicitly disposing controllers
+    // Controllers hold onto native resources and cause memory leaks if not disposed.
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/src/features/auth/signup_screen.dart
+++ b/lib/src/features/auth/signup_screen.dart
@@ -14,6 +14,15 @@ class _SignupScreenState extends State<SignupScreen> {
   final TextEditingController _passwordController = TextEditingController();
 
   @override
+  void dispose() {
+    // ⚡ Bolt: Prevent memory leaks by explicitly disposing controllers
+    // Controllers hold onto native resources and cause memory leaks if not disposed.
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -36,6 +36,17 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
   }
 
   @override
+  void dispose() {
+    // ⚡ Bolt: Prevent memory leaks by explicitly disposing controllers
+    // Controllers hold onto native resources and cause memory leaks if not disposed.
+    _planNameController.dispose();
+    _exerciseNameController.dispose();
+    _setsController.dispose();
+    _repsController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
@@ -116,7 +127,8 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                   final exercise = _exercises[index];
                   return ListTile(
                     title: Text(exercise.name),
-                    subtitle: Text('Sets: ${exercise.sets}, Reps: ${exercise.reps}'),
+                    subtitle:
+                        Text('Sets: ${exercise.sets}, Reps: ${exercise.reps}'),
                   );
                 },
               ),


### PR DESCRIPTION
💡 What: Explicitly disposed of `TextEditingController` instances in `LoginScreen`, `SignupScreen`, and `CreateTrainingPlanScreen` via `dispose()`.
🎯 Why: Controllers hold onto native resources and cause memory leaks if not disposed when the widget is removed from the widget tree.
📊 Impact: Prevents memory leaks, reducing the app's memory footprint and preventing potential crashes over time due to unbounded memory growth.
🔬 Measurement: Verify by reviewing the implementation of `dispose()` in the affected files or by profiling the app's memory usage over time when navigating to and from these screens.

---
*PR created automatically by Jules for task [2007311742782348798](https://jules.google.com/task/2007311742782348798) started by @FabioAmorim1501*