### PR TITLE
🎨 Palette: [UX improvement] Add Empty State to Create Training Plan

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2026-05-27 - Added tooltip to IconButton
 **Learning:** In Flutter, adding a `tooltip` property to an `IconButton` serves a dual purpose: it provides a visual hint on hover/long-press AND it acts as a semantic label for screen readers, similar to an ARIA label in web development. This is a highly effective, low-effort micro-UX improvement for accessibility.
 **Action:** Always look for icon-only buttons in Flutter apps and ensure they have a `tooltip` property defined.
+## 2026-05-29 - Improved Empty State and Form UX in Create Training Plan
+**Learning:** Displaying an empty list without context is a poor user experience. An empty state message (e.g., "No exercises added yet. Add one above!") provides helpful guidance. Additionally, failing to clear form input fields after appending an item forces the user to manually delete old text, adding unnecessary friction.
+**Action:** Always implement empty state fallbacks for dynamic lists like `ListView.builder`. Always clear `TextEditingController` fields after successfully submitting or appending user input in a form.

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -110,24 +110,29 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                     ),
                   );
                 });
+                _exerciseNameController.clear();
+                _setsController.clear();
+                _repsController.clear();
               },
               child: const Text('Add Exercise'),
             ),
             Expanded(
-              child: ListView.builder(
-                itemCount: _exercises.length,
-                itemBuilder: (context, index) {
-                  final exercise = _exercises[index];
-                  return ListTile(
-                    title: Text(exercise.name),
-                    subtitle: Text(
-                      'Sets: ${exercise.sets}, Reps: ${exercise.reps}',
+              child: _exercises.isEmpty
+                  ? const Center(
+                      child: Text('No exercises added yet. Add one above!'),
+                    )
+                  : ListView.builder(
+                      itemCount: _exercises.length,
+                      itemBuilder: (context, index) {
+                        final exercise = _exercises[index];
+                        return ListTile(
+                          title: Text(exercise.name),
+                          subtitle: Text(
+                            'Sets: ${exercise.sets}, Reps: ${exercise.reps}',
+                          ),
+                        );
+                      },
                     ),
-                    subtitle:
-                        Text('Sets: ${exercise.sets}, Reps: ${exercise.reps}'),
-                  );
-                },
-              ),
             ),
           ],
         ),

--- a/lib/src/services/auth_service.dart
+++ b/lib/src/services/auth_service.dart
@@ -11,8 +11,6 @@ class AuthService {
       return null;
     }
     try {
-      final UserCredential userCredential = await _auth
-          .createUserWithEmailAndPassword(email: email, password: password);
       final UserCredential userCredential = await _auth.createUserWithEmailAndPassword(
         email: email.trim(),
         password: password,
@@ -30,8 +28,6 @@ class AuthService {
       return null;
     }
     try {
-      final UserCredential userCredential = await _auth
-          .signInWithEmailAndPassword(email: email, password: password);
       final UserCredential userCredential = await _auth.signInWithEmailAndPassword(
         email: email.trim(),
         password: password,


### PR DESCRIPTION
💡 What: Added an empty state to the `ListView.builder` in `CreateTrainingPlanScreen` and cleared input fields after successfully adding an exercise. Also removed a duplicate `subtitle` parameter and fixed duplicate variable declarations in `AuthService`.
🎯 Why: An empty screen without context is a poor user experience. Empty state messages provide helpful guidance. Clearing input fields saves users from manually deleting old text when adding multiple items sequentially.
📸 Before/After: Before, an empty list showed nothing, and text inputs retained previous values. After, a helpful text prompt appears when empty, and inputs clear automatically after adding.
♿ Accessibility: N/A - primarily a visual flow and interaction improvement.

---
*PR created automatically by Jules for task [16618754385827617108](https://jules.google.com/task/16618754385827617108) started by @FabioAmorim1501*