### PR TITLE
⚡ Bolt: [performance improvement] Isolate reactive list state in CreateTrainingPlanScreen

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-24 - Flutter Memory Leaks from Missing Controller Disposal
 **Learning:** Forgetting to dispose `TextEditingController` objects in StatefulWidgets is a common source of memory leaks in Flutter applications. When a widget is destroyed without disposing its controllers, the controller and any associated listeners remain in memory. Over time, navigating between screens creates multiple instances of these controllers, leading to higher memory consumption. This increases Garbage Collection (GC) pressure, which manifests as jank (dropped frames) during animations and scrolling. This app has numerous screens failing to dispose their controllers.
 **Action:** Always implement the `dispose()` method in `StatefulWidget`s to clean up controllers (`TextEditingController`, `AnimationController`, `ScrollController`, etc.) when the widget is removed from the widget tree.
+
+## 2024-06-05 - ValueNotifier for Form Performance Optimization
+**Learning:** Calling `setState` at the root of a complex Flutter form widget rebuilds all descendant widgets, including expensive `TextField`s. This is highly inefficient when only a small portion of the UI (like a dynamic list of added items) needs to be updated.
+**Action:** Isolate localized reactive state (e.g., dynamic lists) using `ValueNotifier` and wrap the specific dependent UI in a `ValueListenableBuilder`. This prevents unnecessary entire form rebuilds and significantly improves performance during data entry.

--- a/lib/src/features/auth/login_screen.dart
+++ b/lib/src/features/auth/login_screen.dart
@@ -16,20 +16,6 @@ class _LoginScreenState extends State<LoginScreen> {
 
   @override
   void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
-  @override
-  void dispose() {
     // ⚡ Bolt: Disposing TextEditingControllers prevents memory leaks when widget is destroyed.
     // Impact: Reduces memory consumption by cleaning up native resources.
     _emailController.dispose();
@@ -51,41 +37,49 @@ class _LoginScreenState extends State<LoginScreen> {
             ),
             TextField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
-              keyboardType: TextInputType.emailAddress,
-              textInputAction: TextInputAction.next,
-              decoration: const InputDecoration(
-                labelText: 'Email',
-              ),
-              keyboardType: TextInputType.emailAddress,
-              textInputAction: TextInputAction.next,
-            ),
-            TextField(
-              controller: _passwordController,
               textInputAction: TextInputAction.done,
               decoration: const InputDecoration(
                 labelText: 'Password',
               ),
               obscureText: true,
-              textInputAction: TextInputAction.done,
             ),
             ElevatedButton(
               onPressed: _isLoading
                   ? null
                   : () async {
+                      final email = _emailController.text.trim();
+                      final password = _passwordController.text;
+
+                      if (email.isEmpty || password.isEmpty) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              content:
+                                  Text('Please enter email and password.')),
+                        );
+                        return;
+                      }
+
                       setState(() {
                         _isLoading = true;
                       });
+
                       final user = await _auth.login(
-                        _emailController.text,
-                        _passwordController.text,
+                        email,
+                        password,
                       );
+
                       if (mounted) {
                         setState(() {
                           _isLoading = false;
                         });
                         if (user != null) {
                           Navigator.pushReplacementNamed(context, '/home');
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                                content: Text(
+                                    'Login failed. Please check your credentials.')),
+                          );
                         }
                       }
                     },
@@ -96,30 +90,6 @@ class _LoginScreenState extends State<LoginScreen> {
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : const Text('Login'),
-              onPressed: () async {
-                final email = _emailController.text.trim();
-                final password = _passwordController.text;
-
-                if (email.isEmpty || password.isEmpty) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Please enter email and password.')),
-                  );
-                  return;
-                }
-
-                final user = await _auth.login(
-                  email,
-                  password,
-                );
-                if (user != null) {
-                  Navigator.pushReplacementNamed(context, '/home');
-                } else {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Login failed. Please check your credentials.')),
-                  );
-                }
-              },
-              child: const Text('Login'),
             ),
           ],
         ),

--- a/lib/src/features/auth/signup_screen.dart
+++ b/lib/src/features/auth/signup_screen.dart
@@ -16,20 +16,6 @@ class _SignupScreenState extends State<SignupScreen> {
 
   @override
   void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
-  @override
-  void dispose() {
-    _emailController.dispose();
-    _passwordController.dispose();
-    super.dispose();
-  }
-
-  @override
-  void dispose() {
     // ⚡ Bolt: Disposing TextEditingControllers prevents memory leaks when widget is destroyed.
     // Impact: Reduces memory consumption by cleaning up native resources.
     _emailController.dispose();
@@ -51,15 +37,6 @@ class _SignupScreenState extends State<SignupScreen> {
             ),
             TextField(
               controller: _passwordController,
-              decoration: const InputDecoration(labelText: 'Password'),
-              keyboardType: TextInputType.emailAddress,
-              textInputAction: TextInputAction.next,
-              decoration: const InputDecoration(
-                labelText: 'Email',
-              ),
-            ),
-            TextField(
-              controller: _passwordController,
               textInputAction: TextInputAction.done,
               decoration: const InputDecoration(
                 labelText: 'Password',
@@ -70,13 +47,36 @@ class _SignupScreenState extends State<SignupScreen> {
               onPressed: _isLoading
                   ? null
                   : () async {
+                      final email = _emailController.text.trim();
+                      final password = _passwordController.text;
+
+                      if (email.isEmpty || !email.contains('@')) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              content:
+                                  Text('Please enter a valid email address.')),
+                        );
+                        return;
+                      }
+
+                      if (password.length < 8) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                              content: Text(
+                                  'Password must be at least 8 characters long.')),
+                        );
+                        return;
+                      }
+
                       setState(() {
                         _isLoading = true;
                       });
+
                       final user = await _auth.signUp(
-                        _emailController.text,
-                        _passwordController.text,
+                        email,
+                        password,
                       );
+
                       if (mounted) {
                         setState(() {
                           _isLoading = false;
@@ -93,33 +93,6 @@ class _SignupScreenState extends State<SignupScreen> {
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : const Text('Signup'),
-              onPressed: () async {
-                final email = _emailController.text.trim();
-                final password = _passwordController.text;
-
-                if (email.isEmpty || !email.contains('@')) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Please enter a valid email address.')),
-                  );
-                  return;
-                }
-
-                if (password.length < 8) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Password must be at least 8 characters long.')),
-                  );
-                  return;
-                }
-
-                final user = await _auth.signUp(
-                  email,
-                  password,
-                );
-                if (user != null) {
-                  Navigator.pushReplacementNamed(context, '/home');
-                }
-              },
-              child: const Text('Signup'),
             ),
           ],
         ),

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -20,7 +20,7 @@ class CreateTrainingPlanScreen extends StatefulWidget {
 }
 
 class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
-  final List<Exercise> _exercises = [];
+  final ValueNotifier<List<Exercise>> _exercisesNotifier = ValueNotifier([]);
   final TextEditingController _planNameController = TextEditingController();
   final TextEditingController _exerciseNameController = TextEditingController();
   final TextEditingController _setsController = TextEditingController();
@@ -39,6 +39,7 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
   void dispose() {
     // ⚡ Bolt: Disposing TextEditingControllers prevents memory leaks when widget is destroyed.
     // Impact: Reduces memory consumption by cleaning up native resources.
+    _exercisesNotifier.dispose();
     _planNameController.dispose();
     _exerciseNameController.dispose();
     _setsController.dispose();
@@ -62,7 +63,7 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                   name: _planNameController.text,
                   trainerId: _user!.uid,
                   athleteId: widget.athleteId,
-                  exercises: _exercises,
+                  exercises: _exercisesNotifier.value,
                 );
                 _firestoreService.saveTrainingPlan(trainingPlan);
                 Navigator.pop(context);
@@ -101,15 +102,16 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             ),
             ElevatedButton(
               onPressed: () {
-                setState(() {
-                  _exercises.add(
-                    Exercise(
-                      name: _exerciseNameController.text,
-                      sets: int.parse(_setsController.text),
-                      reps: int.parse(_repsController.text),
-                    ),
-                  );
-                });
+                // ⚡ Bolt: Update ValueNotifier instead of triggering a global setState.
+                // Impact: Prevents expensive entire form rebuilds when adding a single exercise.
+                _exercisesNotifier.value = [
+                  ..._exercisesNotifier.value,
+                  Exercise(
+                    name: _exerciseNameController.text,
+                    sets: int.parse(_setsController.text),
+                    reps: int.parse(_repsController.text),
+                  ),
+                ];
                 _exerciseNameController.clear();
                 _setsController.clear();
                 _repsController.clear();
@@ -117,22 +119,27 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
               child: const Text('Add Exercise'),
             ),
             Expanded(
-              child: _exercises.isEmpty
-                  ? const Center(
-                      child: Text('No exercises added yet. Add one above!'),
-                    )
-                  : ListView.builder(
-                      itemCount: _exercises.length,
-                      itemBuilder: (context, index) {
-                        final exercise = _exercises[index];
-                        return ListTile(
-                          title: Text(exercise.name),
-                          subtitle: Text(
-                            'Sets: ${exercise.sets}, Reps: ${exercise.reps}',
-                          ),
+              child: ValueListenableBuilder<List<Exercise>>(
+                valueListenable: _exercisesNotifier,
+                builder: (context, exercises, _) {
+                  return exercises.isEmpty
+                      ? const Center(
+                          child: Text('No exercises added yet. Add one above!'),
+                        )
+                      : ListView.builder(
+                          itemCount: exercises.length,
+                          itemBuilder: (context, index) {
+                            final exercise = exercises[index];
+                            return ListTile(
+                              title: Text(exercise.name),
+                              subtitle: Text(
+                                'Sets: ${exercise.sets}, Reps: ${exercise.reps}',
+                              ),
+                            );
+                          },
                         );
-                      },
-                    ),
+                },
+              ),
             ),
           ],
         ),

--- a/lib/src/models/worker_model.dart
+++ b/lib/src/models/worker_model.dart
@@ -1,4 +1,4 @@
-import 'package.gym_app_alpha/src/models/user_model.dart';
+import 'package:gym_app_alpha/src/models/user_model.dart';
 
 class Worker extends User {
   final String administratorId;


### PR DESCRIPTION
💡 What: 
- Optimized the `CreateTrainingPlanScreen` by migrating the list of exercises from a global `setState` variable to a `ValueNotifier`.
- Wrapped the specific UI elements dependent on the list (the empty state text and the `ListView.builder`) inside a `ValueListenableBuilder`.
- Fixed several logical/syntactical errors in the `login_screen.dart` and `signup_screen.dart` (duplicate arguments, duplicated dispose blocks) and an invalid import in `worker_model.dart` which were blocking successful builds.

🎯 Why: 
In complex Flutter forms, calling `setState` at the root of a widget rebuilds the entire widget tree, including all child `TextField`s. This is highly inefficient. By isolating the reactive state to just the list view, we prevent unnecessary rebuilds.

📊 Impact: 
Significantly reduces memory and CPU overhead during form interaction by isolating rebuilds solely to the dynamic list view, rather than the entire page form framework.

🔬 Measurement: 
Run the app, open the "Create Training Plan" screen, and monitor the Flutter Performance overlay (widget rebuilds count) while adding multiple exercises. The `TextField`s will no longer rebuild upon form submission.

---
*PR created automatically by Jules for task [10431524027107206093](https://jules.google.com/task/10431524027107206093) started by @FabioAmorim1501*