### PR TITLE
🎨 Palette: Add prefix icons and improve input types for auth forms

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -10,3 +10,6 @@
 ## 2026-05-29 - Improved Empty State and Form UX in Create Training Plan
 **Learning:** Displaying an empty list without context is a poor user experience. An empty state message (e.g., "No exercises added yet. Add one above!") provides helpful guidance. Additionally, failing to clear form input fields after appending an item forces the user to manually delete old text, adding unnecessary friction.
 **Action:** Always implement empty state fallbacks for dynamic lists like `ListView.builder`. Always clear `TextEditingController` fields after successfully submitting or appending user input in a form.
+## 2026-06-06 - Enhanced TextFields with prefix icons and appropriate input types
+**Learning:** Including a `prefixIcon` in `TextField` widgets (like an email or lock icon) provides immediate visual recognition for users, reducing cognitive load when filling out forms. Furthermore, explicitly setting `keyboardType` (e.g., `TextInputType.emailAddress`) and `textInputAction` appropriately, while turning off `autocorrect` for fields like emails, greatly streamlines mobile data entry.
+**Action:** Always include a `prefixIcon` for common inputs and configure keyboard and action types to match the expected input.

--- a/lib/src/features/auth/login_screen.dart
+++ b/lib/src/features/auth/login_screen.dart
@@ -33,13 +33,20 @@ class _LoginScreenState extends State<LoginScreen> {
           children: [
             TextField(
               controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+              autocorrect: false,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                prefixIcon: Icon(Icons.email),
+              ),
             ),
             TextField(
               controller: _passwordController,
               textInputAction: TextInputAction.done,
               decoration: const InputDecoration(
                 labelText: 'Password',
+                prefixIcon: Icon(Icons.lock),
               ),
               obscureText: true,
             ),

--- a/lib/src/features/auth/signup_screen.dart
+++ b/lib/src/features/auth/signup_screen.dart
@@ -33,13 +33,20 @@ class _SignupScreenState extends State<SignupScreen> {
           children: [
             TextField(
               controller: _emailController,
-              decoration: const InputDecoration(labelText: 'Email'),
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+              autocorrect: false,
+              decoration: const InputDecoration(
+                labelText: 'Email',
+                prefixIcon: Icon(Icons.email),
+              ),
             ),
             TextField(
               controller: _passwordController,
               textInputAction: TextInputAction.done,
               decoration: const InputDecoration(
                 labelText: 'Password',
+                prefixIcon: Icon(Icons.lock),
               ),
               obscureText: true,
             ),


### PR DESCRIPTION
💡 What: Added `prefixIcon` (email and lock icons) to `TextField`s in `login_screen.dart` and `signup_screen.dart`. Also configured `keyboardType: TextInputType.emailAddress`, `textInputAction: TextInputAction.next`, and `autocorrect: false` for the email input fields.
🎯 Why: Including a prefix icon gives users an immediate visual cue about the expected input, reducing cognitive load when filling out forms. Setting the explicit keyboard type, turning off autocorrect, and using the "next" action significantly streamlines the data entry experience on mobile devices.
📸 Before/After: Visual cue via standard Material icons was added, matching expected common patterns for authentication forms.
♿ Accessibility: Visual cues reduce cognitive friction and the tailored keyboard simplifies user input handling, making the experience smoother for all users.

---
*PR created automatically by Jules for task [11354017029676089030](https://jules.google.com/task/11354017029676089030) started by @FabioAmorim1501*