### PR TITLE
🎨 Palette: [UX improvement] Add prefix icons to form fields

### DIFF
--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -85,23 +85,35 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             TextField(
               controller: _planNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Plan Name'),
+              decoration: const InputDecoration(
+                labelText: 'Plan Name',
+                prefixIcon: Icon(Icons.assignment),
+              ),
             ),
             TextField(
               controller: _exerciseNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Exercise Name'),
+              decoration: const InputDecoration(
+                labelText: 'Exercise Name',
+                prefixIcon: Icon(Icons.fitness_center),
+              ),
             ),
             TextField(
               controller: _setsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Sets'),
+              decoration: const InputDecoration(
+                labelText: 'Sets',
+                prefixIcon: Icon(Icons.repeat),
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(
               controller: _repsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Reps'),
+              decoration: const InputDecoration(
+                labelText: 'Reps',
+                prefixIcon: Icon(Icons.format_list_numbered),
+              ),
               keyboardType: TextInputType.number,
             ),
             ElevatedButton(


### PR DESCRIPTION
💡 What: Added appropriate Material prefix icons to all TextField widgets in the CreateTrainingPlanScreen.
🎯 Why: To improve form usability by providing clear, immediate visual cues for what each input field represents, making the form quicker to parse and fill out.
📸 Before/After: TextFields now display an icon inside the input area aligned with the label text.
♿ Accessibility: Increases visual recognition, helping users who rely more on iconography than text.

---
*PR created automatically by Jules for task [16793446706020573897](https://jules.google.com/task/16793446706020573897) started by @FabioAmorim1501*