### PR TITLE
🎨 Palette: Add loading state to payment button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2026-06-06 - Enhanced TextFields with prefix icons and appropriate input types
 **Learning:** Including a `prefixIcon` in `TextField` widgets (like an email or lock icon) provides immediate visual recognition for users, reducing cognitive load when filling out forms. Furthermore, explicitly setting `keyboardType` (e.g., `TextInputType.emailAddress`) and `textInputAction` appropriately, while turning off `autocorrect` for fields like emails, greatly streamlines mobile data entry.
 **Action:** Always include a `prefixIcon` for common inputs and configure keyboard and action types to match the expected input.
+
+## $(date +%Y-%m-%d) - Adding loading states to async form actions
+**Learning:** It's crucial for UX to give visual feedback to long-running async tasks like external payment service calls. In Flutter, simple localized state management like `ValueNotifier` and `ValueListenableBuilder` are great for wrapping small parts of the widget tree (like a button child) to transition between the idle text and a `CircularProgressIndicator` without rebuilding the whole form, and avoiding "double submits" by using `null` for `onPressed` while loading.
+**Action:** Whenever introducing external API calls or delays, always consider how to visually represent the wait to the user natively and seamlessly.

--- a/lib/src/features/payments/payment_screen.dart
+++ b/lib/src/features/payments/payment_screen.dart
@@ -15,6 +15,7 @@ class PaymentScreen extends StatefulWidget {
 class _PaymentScreenState extends State<PaymentScreen> {
   late final PaymentService _paymentService;
   User? _user;
+  final ValueNotifier<bool> _isLoadingNotifier = ValueNotifier(false);
 
   @override
   void initState() {
@@ -24,24 +25,50 @@ class _PaymentScreenState extends State<PaymentScreen> {
   }
 
   @override
+  void dispose() {
+    _isLoadingNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Payments')),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () {
-            if (_user != null) {
-              _paymentService.makePayment(_user!.uid);
-            } else {
-              // Handle user not logged in
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('You must be logged in to make a payment.'),
-                ),
-              );
-            }
+        child: ValueListenableBuilder<bool>(
+          valueListenable: _isLoadingNotifier,
+          builder: (context, isLoading, child) {
+            return ElevatedButton(
+              onPressed: isLoading
+                  ? null
+                  : () async {
+                      if (_user != null) {
+                        _isLoadingNotifier.value = true;
+                        try {
+                          await _paymentService.makePayment(_user!.uid);
+                        } finally {
+                          if (mounted) {
+                            _isLoadingNotifier.value = false;
+                          }
+                        }
+                      } else {
+                        // Handle user not logged in
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('You must be logged in to make a payment.'),
+                          ),
+                        );
+                      }
+                    },
+              child: isLoading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Make Payment'),
+            );
           },
-          child: const Text('Make Payment'),
         ),
       ),
     );


### PR DESCRIPTION
💡 What: Added a `CircularProgressIndicator` to the "Make Payment" button during the asynchronous `makePayment` call using `ValueListenableBuilder`.
🎯 Why: Long-running external tasks without feedback can lead to users clicking multiple times (double-submitting) or thinking the app is frozen.
📸 Before/After: Before, the button stayed exactly the same after clicking. After, it replaces the text with a spinner and disables clicks while processing.
♿ Accessibility: Prevents double-submission and gives clear visual feedback that a system process is occurring.

---
*PR created automatically by Jules for task [10728277633441268019](https://jules.google.com/task/10728277633441268019) started by @FabioAmorim1501*