### PR TITLE
🎨 Palette: [UX improvement] Enhance TextFields in Create Training Plan screen

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-06-06 - Enhanced TextFields with prefix icons and appropriate input types
 **Learning:** Including a `prefixIcon` in `TextField` widgets (like an email or lock icon) provides immediate visual recognition for users, reducing cognitive load when filling out forms. Furthermore, explicitly setting `keyboardType` (e.g., `TextInputType.emailAddress`) and `textInputAction` appropriately, while turning off `autocorrect` for fields like emails, greatly streamlines mobile data entry.
 **Action:** Always include a `prefixIcon` for common inputs and configure keyboard and action types to match the expected input.
+## 2026-06-09 - Maintained Layout Stability when using maxLength in Forms
+**Learning:** When using `maxLength` on a `TextField` to restrict input length (for DoS prevention), Flutter automatically displays a character counter below the input. This counter causes an unwanted layout shift, increasing the height of the field and cluttering the form visually.
+**Action:** Always include `counterText: ''` inside the `InputDecoration` of any `TextField` that utilizes `maxLength` if the visible counter is not strictly necessary. This acts as a micro-UX improvement by maintaining layout stability. Furthermore, always configure `textInputAction` (e.g., `TextInputAction.next` or `TextInputAction.done`) to streamline the keyboard navigation flow.

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -85,23 +85,43 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             TextField(
               controller: _planNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Plan Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Plan Name',
+                counterText: '',
+                prefixIcon: Icon(Icons.assignment),
+              ),
             ),
             TextField(
               controller: _exerciseNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Exercise Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Exercise Name',
+                counterText: '',
+                prefixIcon: Icon(Icons.fitness_center),
+              ),
             ),
             TextField(
               controller: _setsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Sets'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Sets',
+                counterText: '',
+                prefixIcon: Icon(Icons.repeat),
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(
               controller: _repsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Reps'),
+              textInputAction: TextInputAction.done,
+              decoration: const InputDecoration(
+                labelText: 'Reps',
+                counterText: '',
+                prefixIcon: Icon(Icons.replay),
+              ),
               keyboardType: TextInputType.number,
             ),
             ElevatedButton(


### PR DESCRIPTION
- 💡 What: Added `counterText: ''`, `textInputAction` (next/done), and contextual `prefixIcon`s to all `TextField` widgets in the `CreateTrainingPlanScreen`.
- 🎯 Why: Using `maxLength` on inputs generates a character counter that causes visual clutter and layout shifts. Hiding it provides a cleaner UI. Setting input actions improves mobile keyboard navigation flow. Prefix icons aid quick visual recognition of the field's purpose.
- ♿ Accessibility: Improved form navigability via more explicit input action types.

---
*PR created automatically by Jules for task [2234532412169280479](https://jules.google.com/task/2234532412169280479) started by @FabioAmorim1501*