### PR TITLE
🎨 Palette: Enhance text inputs in Create Training Plan form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-06-06 - Enhanced TextFields with prefix icons and appropriate input types
 **Learning:** Including a `prefixIcon` in `TextField` widgets (like an email or lock icon) provides immediate visual recognition for users, reducing cognitive load when filling out forms. Furthermore, explicitly setting `keyboardType` (e.g., `TextInputType.emailAddress`) and `textInputAction` appropriately, while turning off `autocorrect` for fields like emails, greatly streamlines mobile data entry.
 **Action:** Always include a `prefixIcon` for common inputs and configure keyboard and action types to match the expected input.
+## 2026-06-10 - Streamlined mobile form navigation with TextInputAction
+**Learning:** For optimal mobile form UX in Flutter, configuring intermediate `TextField` widgets with `textInputAction: TextInputAction.next` and the final field with `TextInputAction.done` allows users to smoothly jump between fields without dismissing the on-screen keyboard. This, combined with `prefixIcon`s, drastically reduces cognitive load and data entry friction.
+**Action:** Always verify that multi-field forms have correct `textInputAction` sequences configured to support continuous keyboard navigation.

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -85,23 +85,43 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             TextField(
               controller: _planNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Plan Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Plan Name',
+                prefixIcon: Icon(Icons.assignment),
+                counterText: '',
+              ),
             ),
             TextField(
               controller: _exerciseNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Exercise Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Exercise Name',
+                prefixIcon: Icon(Icons.fitness_center),
+                counterText: '',
+              ),
             ),
             TextField(
               controller: _setsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Sets'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Sets',
+                prefixIcon: Icon(Icons.repeat),
+                counterText: '',
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(
               controller: _repsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Reps'),
+              textInputAction: TextInputAction.done,
+              decoration: const InputDecoration(
+                labelText: 'Reps',
+                prefixIcon: Icon(Icons.replay),
+                counterText: '',
+              ),
               keyboardType: TextInputType.number,
             ),
             ElevatedButton(
@@ -113,7 +133,9 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                 if (name.isEmpty || sets == null || reps == null) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
-                      content: Text('Please enter valid exercise name, sets, and reps.'),
+                      content: Text(
+                        'Please enter valid exercise name, sets, and reps.',
+                      ),
                     ),
                   );
                   return;
@@ -123,11 +145,7 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                 // Impact: Prevents expensive entire form rebuilds when adding a single exercise.
                 _exercisesNotifier.value = [
                   ..._exercisesNotifier.value,
-                  Exercise(
-                    name: name,
-                    sets: sets,
-                    reps: reps,
-                  ),
+                  Exercise(name: name, sets: sets, reps: reps),
                 ];
                 _exerciseNameController.clear();
                 _setsController.clear();


### PR DESCRIPTION
💡 What: Added `prefixIcon`s, sequential `textInputAction`s, and hid the `maxLength` counter text for all `TextField` widgets in the Create Training Plan form.
🎯 Why: To improve visual recognition of inputs, streamline mobile keyboard navigation (allowing users to "next" through fields without dismissing the keyboard), and prevent subtle UI layout shifts when typing.
📸 Before/After: Before, fields were plain text inputs that required dismissing the keyboard to switch fields. After, fields have icons (Assignment, Fitness Center, Repeat, Replay) and the keyboard includes a "Next" button.
♿ Accessibility: Improved cognitive accessibility by providing consistent visual icons alongside text labels.

---
*PR created automatically by Jules for task [8304833384671315674](https://jules.google.com/task/8304833384671315674) started by @FabioAmorim1501*