### PR TITLE
🎨 Palette: [UX improvement] Enhance Create Training Plan form fields

### DIFF
--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -85,23 +85,43 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             TextField(
               controller: _planNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Plan Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Plan Name',
+                counterText: '',
+                prefixIcon: Icon(Icons.assignment),
+              ),
             ),
             TextField(
               controller: _exerciseNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Exercise Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Exercise Name',
+                counterText: '',
+                prefixIcon: Icon(Icons.fitness_center),
+              ),
             ),
             TextField(
               controller: _setsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Sets'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Sets',
+                counterText: '',
+                prefixIcon: Icon(Icons.repeat),
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(
               controller: _repsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Reps'),
+              textInputAction: TextInputAction.done,
+              decoration: const InputDecoration(
+                labelText: 'Reps',
+                counterText: '',
+                prefixIcon: Icon(Icons.replay),
+              ),
               keyboardType: TextInputType.number,
             ),
             ElevatedButton(


### PR DESCRIPTION
💡 **What**:
Enhanced the `TextField` widgets in the `CreateTrainingPlanScreen` by:
1. Adding `textInputAction` attributes (`TextInputAction.next` for intermediate fields, `TextInputAction.done` for the final field).
2. Adding `counterText: ''` to the `InputDecoration` of all fields.
3. Adding context-appropriate `prefixIcon`s (e.g., `Icons.assignment`, `Icons.fitness_center`, `Icons.repeat`, `Icons.replay`) to all fields.

🎯 **Why**:
- **Keyboard Navigation**: The `textInputAction` improves the mobile keyboard experience by allowing users to smoothly jump from one input field to the next without the keyboard dismissing and having to manually tap the next field.
- **Visual Clarity**: Hiding the character counter (`counterText: ''`) for small, self-evident fields like "Sets" and "Reps" reduces unnecessary UI clutter.
- **Visual Recognition**: Prefix icons help users quickly identify the purpose of the field at a glance, reducing cognitive load.

♿ **Accessibility**:
The use of standard `prefixIcon` and keyboard actions are natively supported by Flutter's accessibility framework, providing better semantic structure and navigation flow for screen readers and keyboard users.

📸 **Before/After**: (Visual changes on the device/emulator)
- The fields now have leading icons.
- The `0/3` or `0/50` text below the fields is gone.
- The keyboard's bottom right button now shows "Next" instead of "Done" for the first three fields.

---
*PR created automatically by Jules for task [11983972618524864124](https://jules.google.com/task/11983972618524864124) started by @FabioAmorim1501*