### PR TITLE
🎨 Palette: Improve Create Training Plan form UX

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,6 @@
 ## 2026-06-06 - Enhanced TextFields with prefix icons and appropriate input types
 **Learning:** Including a `prefixIcon` in `TextField` widgets (like an email or lock icon) provides immediate visual recognition for users, reducing cognitive load when filling out forms. Furthermore, explicitly setting `keyboardType` (e.g., `TextInputType.emailAddress`) and `textInputAction` appropriately, while turning off `autocorrect` for fields like emails, greatly streamlines mobile data entry.
 **Action:** Always include a `prefixIcon` for common inputs and configure keyboard and action types to match the expected input.
+## 2026-06-12 - Adding prefixIcons and textInputActions to Training Plan Form
+**Learning:** When making multiple data entry fields, users navigate via the keyboard next button. Visual icons (like `prefixIcon`) greatly reduce cognitive load when identifying the purpose of dense form inputs in a mobile layout.
+**Action:** Always include `prefixIcon` and appropriate `textInputAction` attributes (like `TextInputAction.next`) to multi-field forms.

--- a/lib/src/features/training_plans/create_training_plan_screen.dart
+++ b/lib/src/features/training_plans/create_training_plan_screen.dart
@@ -85,23 +85,39 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
             TextField(
               controller: _planNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Plan Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Plan Name',
+                prefixIcon: Icon(Icons.assignment),
+              ),
             ),
             TextField(
               controller: _exerciseNameController,
               maxLength: 50,
-              decoration: const InputDecoration(labelText: 'Exercise Name'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Exercise Name',
+                prefixIcon: Icon(Icons.fitness_center),
+              ),
             ),
             TextField(
               controller: _setsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Sets'),
+              textInputAction: TextInputAction.next,
+              decoration: const InputDecoration(
+                labelText: 'Sets',
+                prefixIcon: Icon(Icons.repeat),
+              ),
               keyboardType: TextInputType.number,
             ),
             TextField(
               controller: _repsController,
               maxLength: 3,
-              decoration: const InputDecoration(labelText: 'Reps'),
+              textInputAction: TextInputAction.done,
+              decoration: const InputDecoration(
+                labelText: 'Reps',
+                prefixIcon: Icon(Icons.refresh),
+              ),
               keyboardType: TextInputType.number,
             ),
             ElevatedButton(
@@ -113,7 +129,8 @@ class _CreateTrainingPlanScreenState extends State<CreateTrainingPlanScreen> {
                 if (name.isEmpty || sets == null || reps == null) {
                   ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(
-                      content: Text('Please enter valid exercise name, sets, and reps.'),
+                      content: Text(
+                          'Please enter valid exercise name, sets, and reps.'),
                     ),
                   );
                   return;


### PR DESCRIPTION
💡 What: Added `textInputAction`s and `prefixIcon`s to the TextFields in `CreateTrainingPlanScreen`.
🎯 Why: To improve keyboard navigation on mobile devices and provide immediate visual context for the input fields.
📸 Before/After: Visual update includes icons in TextFields (assignment, fitness_center, repeat, refresh). Soft keyboard now flows seamlessly from one field to the next.
♿ Accessibility: Better keyboard support and visual labeling.

---
*PR created automatically by Jules for task [11525059984825395650](https://jules.google.com/task/11525059984825395650) started by @FabioAmorim1501*